### PR TITLE
Poorly-tested fix for MacOS

### DIFF
--- a/plot.c
+++ b/plot.c
@@ -123,8 +123,19 @@ static void *alloc(size_t nmemb, size_t size) {
         return calloc( nmemb, size );
     }
     else {
+
+#if __APPLE__
         // allocate memory on a 4K boundary for O_DIRECT.  Otherwise `write` gives `errno` 22
+        void* return_ptr;
+        int err = posix_memalign(&return_ptr, 4096, nmemb * size);
+        if (err) {
+            printf("\n\nError while allocating memory with posix_memalign: %d\n\n", errno);
+            exit(1);
+        }
+        return return_ptr;        
+#else
         return aligned_alloc( 4096, nmemb * size );
+#endif
     }
 }
 

--- a/test.pl
+++ b/test.pl
@@ -42,8 +42,12 @@ else {
     cmp_digest('core2/11424087411148401423_0_128_128', $expected);
 }
 
+# Test Core 0 with Direct IO
+print qx{$plotbin -D -a -v -k 11424087411148401423 -d core0_dio -x 0 -s 0 -n 128 -t 4};
+cmp_digest('core0_dio/11424087411148401423_0_128_128', $expected);
+
 # cleanup
-qx{rm -rf core0 core1 core2} if (!$keep);
+qx{rm -rf core0 core1 core2 core0_dio} if (!$keep);
 
 sub cmp_digest {
     my $file   = shift;


### PR DESCRIPTION
MacOS does not have aligned_alloc().  Use posix_memalign() instead.
Also added another iteration of the core0 test with the -D option just to exercise this codepath.

It seems to work, but as the title says, poorly tested.