### PR TITLE
Add an error message rather than crashing when an existing plot file is empty.

### DIFF
--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -204,15 +204,14 @@ impl Plotter {
         let mut progress = 0;
         if file.exists() {
             if !task.quiet {
-                print!("File already exists, reading resume info...");
+                println!("File already exists, reading resume info...");
             }
             let resume_info = read_resume_info(&file);
             match resume_info {
                 Ok(x) => progress = x,
                 Err(_) => {
-                    println!("Error:");
-                    println!("File is already completed.\n");
-                    println!("But if you are sure that this file is incomplete \
+                    println!("Error: couldn't read resume info from file '{}'", file.display());
+                    println!("If you are sure that this file is incomplete \
                               or corrupted, then delete it before continuing.");
                     println!("Shutting Down...");
                     return;
@@ -227,7 +226,12 @@ impl Plotter {
             }
             if !task.benchmark {
                 preallocate(&file, plotsize, task.direct_io);
-                write_resume_info(&file, 0u64);
+                match write_resume_info(&file, 0u64) {
+                    Err(_) => {
+                        println!("Error: couldn't write resume info");
+                    }
+                    Ok(_) => (),
+                }
             }
             if !task.quiet {
                 println!("OK");

--- a/src/plotter.rs
+++ b/src/plotter.rs
@@ -210,8 +210,10 @@ impl Plotter {
             match resume_info {
                 Ok(x) => progress = x,
                 Err(_) => {
-                    println!("Error");
-                    println!("File is already completed.");
+                    println!("Error:");
+                    println!("File is already completed.\n");
+                    println!("But if you are sure that this file is incomplete \
+                              or corrupted, then delete it before continuing.");
                     println!("Shutting Down...");
                     return;
                 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,7 +2,7 @@ use crate::plotter::{Buffer, PlotterTask, NONCE_SIZE, SCOOP_SIZE};
 use crate::utils::{open, open_r, open_using_direct_io};
 use crossbeam_channel::{Receiver, Sender};
 use std::cmp::min;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom, Write, Error, ErrorKind};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -87,41 +87,46 @@ pub fn create_writer_thread(
             }
 
             if !task.benchmark {
-                write_resume_info(&filename, nonces_written);
+                match write_resume_info(&filename, nonces_written) {
+                    Err(_) => {
+                        println!("Error: couldn't write resume info");
+                    }
+                    Ok(_) => (),
+                }
             }
             tx_empty_buffers.send(buffer).unwrap();
         }
     }
 }
 
-pub fn read_resume_info(file: &Path) -> Result<u64, u64> {
-    let mut file = open_r(&file).unwrap();
-    if file.seek(SeekFrom::End(-8)).is_err() {
-        return Err(0);
-    }
+pub fn read_resume_info(file: &Path) -> Result<u64, Error> {
+    let mut file = open_r(&file)?;
+    file.seek(SeekFrom::End(-8))?;
+      
 
     let mut progress = [0u8; 4];
     let mut double_monkey = [0u8; 4];
 
-    file.read_exact(&mut progress[0..4]).unwrap();
-    file.read_exact(&mut double_monkey[0..4]).unwrap();
+    file.read_exact(&mut progress[0..4])?;
+    file.read_exact(&mut double_monkey[0..4])?;
 
     if double_monkey == [0xAF, 0xFE, 0xAF, 0xFE] {
         Ok(u64::from(as_u32_le(progress)))
     } else {
-        Err(0)
+        Err(Error::new(ErrorKind::Other, "End marker not found"))
     }
 }
 
-pub fn write_resume_info(file: &Path, nonces_written: u64) {
-    let mut file = open(&file).unwrap();
-    file.seek(SeekFrom::End(-8)).unwrap();
+pub fn write_resume_info(file: &Path, nonces_written: u64) -> Result<(), Error> {
+    let mut file = open(&file)?;
+    file.seek(SeekFrom::End(-8))?;
 
     let progress = as_u8_le(nonces_written as u32);
     let double_monkey = [0xAF, 0xFE, 0xAF, 0xFE];
 
-    file.write_all(&progress[0..4]).unwrap();
-    file.write_all(&double_monkey[0..4]).unwrap();
+    file.write_all(&progress[0..4])?;
+    file.write_all(&double_monkey[0..4])?;
+    Ok(())    
 }
 
 fn as_u32_le(array: [u8; 4]) -> u32 {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -96,7 +96,9 @@ pub fn create_writer_thread(
 
 pub fn read_resume_info(file: &Path) -> Result<u64, u64> {
     let mut file = open_r(&file).unwrap();
-    file.seek(SeekFrom::End(-8)).unwrap();
+    if file.seek(SeekFrom::End(-8)).is_err() {
+        return Err(0);
+    }
 
     let mut progress = [0u8; 4];
     let mut double_monkey = [0u8; 4];


### PR DESCRIPTION
This can happen when the preallocating step fails on a previous run, for example on an ext4 filesystem.

I'll look at fixing the root cause of the empty files in another PR, but this just makes it print an error instead of crashing. The reason is that seeking to negative values is invalid.